### PR TITLE
Ensure addresses instance variable is array

### DIFF
--- a/src/Forms/SignupPageValidator.php
+++ b/src/Forms/SignupPageValidator.php
@@ -11,7 +11,7 @@ class SignupPageValidator extends RequiredFields
      *
      * @var array
      */
-    protected $addresses;
+    protected $addresses = [];
 
     /**
      * Adds a address field to addresses stack.


### PR DESCRIPTION
If left as null, the validation throws a warning that null is not countable. Alternative, the conditions there can be changed to check for array and then count it.